### PR TITLE
Previous vasync version was buggy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         },
         "dependencies": {
                 "bunyan": "0.7.0",
-                "vasync": "1.0.1"
+                "vasync": "1.1.1"
         },
         "devDependencies": {
                 "cover": "0.2.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
         "name": "pooling",
         "description": "General purpose resource pool API",
-        "version": "0.2.0",
+        "version": "0.2.1",
         "author": "Mark Cavage <mcavage@gmail.com>",
         "main": "lib/index.js",
         "repository": {


### PR DESCRIPTION
The previous vasync version in use had a bug where it wasn't returning any result when all the items given to `forEachParallel` or `parallel` return success. Therefore `Pool._reap` was throwing an exception "cannot access property operations of undefined ..." when all the pool members were OK.
