### PR TITLE
Update to make dtrace-provider an optional dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ cscope.*
 node_modules
 .coverage_data
 *.tgz
+.DS_Store

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -2,9 +2,7 @@
 
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
-
 var assert = require('assert-plus');
-var dtrace = require('dtrace-provider');
 var once = require('once');
 var vasync = require('vasync');
 
@@ -55,13 +53,36 @@ util.inherits(PoolShuttingDownError, Error);
 ///--- Internal Functions
 
 function createDTraceProbes(name) {
+        var dtp = null;
+        try {
+                var dtrace = require('dtrace-provider');
+                dtp = dtrace.createDTraceProvider(name);
+        } catch (e) {
+                dtp = {
+                        fire: function () {
+                        },
+                        enable: function () {
+                        },
+                        addProbe: function () {
+                                var p = {
+                                                fire: function () {
+                                        }
+                                };
+
+                                return (p);
+                        },
+                        removeProbe: function () {
+                        },
+                        disable: function () {
+                        }
+                };
+        }
         assert.string(name, 'name');
 
         if (DTPS[name]) {
                 return (DTPS[name]);
         }
 
-        var dtp = dtrace.createDTraceProvider(name);
         var probes = {
                 // these are all object_id, state
                 release: dtp.addProbe('release', 'int', 'json'),

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
         },
         "dependencies": {
                 "assert-plus": "0.1.4",
-                "dtrace-provider": "0.2.8",
                 "bunyan": "0.22.0",
                 "once": "1.3.0",
                 "vasync": "1.4.0"
+        },
+        "optionalDependencies": {
+                "dtrace-provider": "0.2.8"
         },
         "devDependencies": {
                 "cover": "0.2.9",


### PR DESCRIPTION
Hi Mark, 

I'm trying to get node-ldapjs working on Windows without the need to compile the dtrace-provider dependencies and as this module is a dependency of node-ldapjs I have modified it to make dtrace-provider optional. 

I haven't modified the test script to run in a Windows environment but all tests are passing on OSX with dtrace-provider installed and also without.

Thanks, 
Evan 
